### PR TITLE
feat(models): add League.previous_league_id for season chaining

### DIFF
--- a/sleeper_mcp_server/models.py
+++ b/sleeper_mcp_server/models.py
@@ -72,6 +72,9 @@ class League(BaseModel):
     roster_positions: List[str] = Field(..., description="Available roster positions")
     total_rosters: int = Field(..., ge=2, le=32, description="Total number of rosters")
     draft_id: Optional[str] = Field(None, description="Draft identifier if applicable")
+    previous_league_id: Optional[str] = Field(
+        None, description="League ID of the prior season's league (season chaining)"
+    )
     avatar: Optional[str] = Field(None, description="League avatar URL")
     
     @field_validator('roster_positions')

--- a/tests/test_models_previous_league_id.py
+++ b/tests/test_models_previous_league_id.py
@@ -1,0 +1,21 @@
+from sleeper_mcp_server.models import League
+
+
+def _base(**over):
+    d = {
+        "league_id": "L", "name": "Test", "season": "2026", "status": "pre_draft",
+        "settings": {"num_teams": 12, "playoff_teams": 6}, "roster_positions": ["RB", "WR"],
+        "total_rosters": 12,
+    }
+    d.update(over)
+    return d
+
+
+def test_previous_league_id_parsed_when_present():
+    lg = League.model_validate(_base(previous_league_id="PREV123"))
+    assert lg.previous_league_id == "PREV123"
+
+
+def test_previous_league_id_defaults_none():
+    lg = League.model_validate(_base())
+    assert lg.previous_league_id is None


### PR DESCRIPTION
## Add `League.previous_league_id`

Adds the single optional `previous_league_id` field to the `League` model. Sleeper's league object returns it (it chains leagues across seasons), but the model previously dropped it.

Additive and backward-compatible (defaults to `None` when absent). Enables season-chaining for the private `sleeper-analytics` draft engine (Phase 2 Spec 2b walks a league's lineage via this field).

2 new model tests; full suite 22/22 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
