### PR TITLE
refactor(cache): narrow CacheManager to get and set

### DIFF
--- a/sleeper_mcp_server/cache.py
+++ b/sleeper_mcp_server/cache.py
@@ -1,31 +1,28 @@
-"""
-Cache manager with TTL-based expiration for different data types.
+"""In-process TTL cache for Sleeper API responses.
 
-This module provides a comprehensive caching system for the Sleeper MCP server,
-with configurable TTL values for different data types and cache hit/miss logging
-for performance monitoring.
+Callers state a TTL directly. The named constants below carry the intent
+that used to live in a data-type-to-TTL table.
 """
 
 import logging
 import time
-from datetime import datetime, timedelta
-from typing import Any, Dict, Optional, TypeVar, Generic
+from typing import Any, Dict, Generic, Optional, TypeVar
 from threading import Lock
 from dataclasses import dataclass
-from enum import Enum
 
 T = TypeVar('T')
 
 logger = logging.getLogger(__name__)
 
 
-class CacheDataType(str, Enum):
-    """Enum for different types of cached data with their default TTL values."""
-    PLAYER_DATA = "player_data"  # 1 hour TTL
-    LEAGUE_SETTINGS = "league_settings"  # 24 hours TTL
-    MATCHUP_DATA = "matchup_data"  # 5 minutes TTL during games, 1 hour otherwise
-    TRENDING_PLAYERS = "trending_players"  # 30 minutes TTL
-    ROSTER_DATA = "roster_data"  # 15 minutes TTL
+# TTLs in seconds. Several share a value; the names carry the intent.
+LEAGUE_SETTINGS_TTL = 86400  # league info, draft results - effectively static
+LEAGUE_LIST_TTL = 3600  # a user's leagues, a league's users
+ROSTER_TTL = 900  # rosters change on waivers and trades
+PLAYER_TTL = 3600  # player search, player stats
+TRENDING_TTL = 1800  # trending adds/drops move fast
+MATCHUP_LIVE_TTL = 300  # games in progress
+MATCHUP_FINAL_TTL = 3600  # completed week
 
 
 @dataclass
@@ -34,342 +31,70 @@ class CacheEntry(Generic[T]):
     data: T
     expires_at: float
     created_at: float
-    data_type: CacheDataType
-    
+
     def is_expired(self) -> bool:
         """Check if the cache entry has expired."""
         return time.time() > self.expires_at
-    
+
     def age_seconds(self) -> float:
         """Get the age of the cache entry in seconds."""
         return time.time() - self.created_at
 
 
 class CacheManager:
+    """Thread-safe TTL cache.
+
+    Entries expire on read; there is no background eviction. Nothing in this
+    server writes to Sleeper, so expiry is the only invalidation mechanism.
     """
-    Thread-safe cache manager with TTL-based expiration for different data types.
-    
-    Provides caching functionality with configurable TTL values, cache invalidation
-    strategies, and performance monitoring through hit/miss logging.
-    """
-    
-    # Default TTL values in seconds for different data types
-    DEFAULT_TTL_CONFIG = {
-        CacheDataType.PLAYER_DATA: 3600,  # 1 hour
-        CacheDataType.LEAGUE_SETTINGS: 86400,  # 24 hours
-        CacheDataType.MATCHUP_DATA: 3600,  # 1 hour (default, can be overridden)
-        CacheDataType.TRENDING_PLAYERS: 1800,  # 30 minutes
-        CacheDataType.ROSTER_DATA: 900,  # 15 minutes
-    }
-    
-    def __init__(self, ttl_config: Optional[Dict[CacheDataType, int]] = None):
-        """
-        Initialize the cache manager.
-        
-        Args:
-            ttl_config: Optional custom TTL configuration for data types
-        """
+
+    def __init__(self) -> None:
+        """Initialize an empty cache."""
         self._cache: Dict[str, CacheEntry] = {}
         self._lock = Lock()
-        self._ttl_config = {**self.DEFAULT_TTL_CONFIG}
-        if ttl_config:
-            self._ttl_config.update(ttl_config)
-        
-        # Performance monitoring counters
-        self._stats = {
-            'hits': 0,
-            'misses': 0,
-            'evictions': 0,
-            'invalidations': 0
-        }
-        
-        logger.info(f"Cache manager initialized with TTL config: {self._ttl_config}")
-    
-    def get(self, key: str, data_type: CacheDataType) -> Optional[Any]:
+
+    def get(self, key: str) -> Optional[Any]:
         """
         Retrieve data from cache if it exists and hasn't expired.
-        
+
         Args:
             key: Cache key
-            data_type: Type of data being cached
-            
+
         Returns:
             Cached data if available and not expired, None otherwise
         """
         with self._lock:
             entry = self._cache.get(key)
-            
+
             if entry is None:
-                self._stats['misses'] += 1
-                logger.debug(f"Cache miss for key: {key} (type: {data_type})")
+                logger.debug(f"Cache miss for key: {key}")
                 return None
-            
+
             if entry.is_expired():
-                # Remove expired entry
                 del self._cache[key]
-                self._stats['evictions'] += 1
-                self._stats['misses'] += 1
-                logger.debug(f"Cache expired for key: {key} (type: {data_type}, age: {entry.age_seconds():.1f}s)")
+                logger.debug(f"Cache expired for key: {key} (age: {entry.age_seconds():.1f}s)")
                 return None
-            
-            self._stats['hits'] += 1
-            logger.debug(f"Cache hit for key: {key} (type: {data_type}, age: {entry.age_seconds():.1f}s)")
+
+            logger.debug(f"Cache hit for key: {key} (age: {entry.age_seconds():.1f}s)")
             return entry.data
-    
-    def set(self, key: str, data: Any, data_type: CacheDataType, ttl_override: Optional[int] = None) -> None:
+
+    def set(self, key: str, data: Any, ttl: int) -> None:
         """
         Store data in cache with TTL-based expiration.
-        
+
         Args:
             key: Cache key
             data: Data to cache
-            data_type: Type of data being cached
-            ttl_override: Optional TTL override in seconds
+            ttl: Seconds until the entry expires
         """
-        ttl = ttl_override if ttl_override is not None else self._ttl_config[data_type]
         current_time = time.time()
-        expires_at = current_time + ttl
-        
         entry = CacheEntry(
             data=data,
-            expires_at=expires_at,
+            expires_at=current_time + ttl,
             created_at=current_time,
-            data_type=data_type
         )
-        
+
         with self._lock:
             self._cache[key] = entry
-        
-        logger.debug(f"Cached data for key: {key} (type: {data_type}, TTL: {ttl}s)")
-    
-    def invalidate(self, key: str) -> bool:
-        """
-        Remove a specific key from cache.
-        
-        Args:
-            key: Cache key to invalidate
-            
-        Returns:
-            True if key was found and removed, False otherwise
-        """
-        with self._lock:
-            if key in self._cache:
-                del self._cache[key]
-                self._stats['invalidations'] += 1
-                logger.debug(f"Invalidated cache key: {key}")
-                return True
-            return False
-    
-    def invalidate_by_pattern(self, pattern: str) -> int:
-        """
-        Remove all keys matching a pattern from cache.
-        
-        Args:
-            pattern: Pattern to match (simple string contains matching)
-            
-        Returns:
-            Number of keys invalidated
-        """
-        keys_to_remove = []
-        
-        with self._lock:
-            for key in self._cache.keys():
-                if pattern in key:
-                    keys_to_remove.append(key)
-            
-            for key in keys_to_remove:
-                del self._cache[key]
-                self._stats['invalidations'] += 1
-        
-        if keys_to_remove:
-            logger.debug(f"Invalidated {len(keys_to_remove)} cache keys matching pattern: {pattern}")
-        
-        return len(keys_to_remove)
-    
-    def invalidate_by_type(self, data_type: CacheDataType) -> int:
-        """
-        Remove all entries of a specific data type from cache.
-        
-        Args:
-            data_type: Type of data to invalidate
-            
-        Returns:
-            Number of entries invalidated
-        """
-        keys_to_remove = []
-        
-        with self._lock:
-            for key, entry in self._cache.items():
-                if entry.data_type == data_type:
-                    keys_to_remove.append(key)
-            
-            for key in keys_to_remove:
-                del self._cache[key]
-                self._stats['invalidations'] += 1
-        
-        if keys_to_remove:
-            logger.debug(f"Invalidated {len(keys_to_remove)} cache entries of type: {data_type}")
-        
-        return len(keys_to_remove)
-    
-    def clear(self) -> int:
-        """
-        Clear all entries from cache.
-        
-        Returns:
-            Number of entries cleared
-        """
-        with self._lock:
-            count = len(self._cache)
-            self._cache.clear()
-            self._stats['invalidations'] += count
-        
-        logger.info(f"Cleared all cache entries ({count} entries)")
-        return count
-    
-    def cleanup_expired(self) -> int:
-        """
-        Remove all expired entries from cache.
-        
-        Returns:
-            Number of expired entries removed
-        """
-        current_time = time.time()
-        keys_to_remove = []
-        
-        with self._lock:
-            for key, entry in self._cache.items():
-                if entry.expires_at <= current_time:
-                    keys_to_remove.append(key)
-            
-            for key in keys_to_remove:
-                del self._cache[key]
-                self._stats['evictions'] += 1
-        
-        if keys_to_remove:
-            logger.debug(f"Cleaned up {len(keys_to_remove)} expired cache entries")
-        
-        return len(keys_to_remove)
-    
-    def get_stats(self) -> Dict[str, Any]:
-        """
-        Get cache performance statistics.
-        
-        Returns:
-            Dictionary containing cache statistics
-        """
-        with self._lock:
-            total_requests = self._stats['hits'] + self._stats['misses']
-            hit_rate = (self._stats['hits'] / total_requests * 100) if total_requests > 0 else 0
-            
-            return {
-                'hits': self._stats['hits'],
-                'misses': self._stats['misses'],
-                'hit_rate_percent': round(hit_rate, 2),
-                'evictions': self._stats['evictions'],
-                'invalidations': self._stats['invalidations'],
-                'total_entries': len(self._cache),
-                'total_requests': total_requests
-            }
-    
-    def get_cache_info(self) -> Dict[str, Any]:
-        """
-        Get detailed information about cache contents.
-        
-        Returns:
-            Dictionary containing cache information
-        """
-        current_time = time.time()
-        info = {
-            'total_entries': 0,
-            'expired_entries': 0,
-            'entries_by_type': {},
-            'oldest_entry_age': 0,
-            'newest_entry_age': 0
-        }
-        
-        with self._lock:
-            if not self._cache:
-                return info
-            
-            ages = []
-            for entry in self._cache.values():
-                age = current_time - entry.created_at
-                ages.append(age)
-                
-                # Count by type
-                type_name = entry.data_type.value
-                if type_name not in info['entries_by_type']:
-                    info['entries_by_type'][type_name] = {'count': 0, 'expired': 0}
-                
-                info['entries_by_type'][type_name]['count'] += 1
-                
-                if entry.is_expired():
-                    info['expired_entries'] += 1
-                    info['entries_by_type'][type_name]['expired'] += 1
-            
-            info['total_entries'] = len(self._cache)
-            if ages:
-                info['oldest_entry_age'] = max(ages)
-                info['newest_entry_age'] = min(ages)
-        
-        return info
-    
-    def get_matchup_ttl(self, is_game_time: bool = False) -> int:
-        """
-        Get TTL for matchup data based on whether games are currently active.
-        
-        Args:
-            is_game_time: Whether games are currently being played
-            
-        Returns:
-            TTL in seconds (5 minutes during games, 1 hour otherwise)
-        """
-        return 300 if is_game_time else 3600  # 5 minutes vs 1 hour
-    
-    def log_performance_summary(self) -> None:
-        """Log a summary of cache performance statistics."""
-        stats = self.get_stats()
-        info = self.get_cache_info()
-        
-        logger.info(
-            f"Cache Performance Summary - "
-            f"Hit Rate: {stats['hit_rate_percent']}% "
-            f"({stats['hits']}/{stats['total_requests']} requests), "
-            f"Entries: {info['total_entries']} "
-            f"(Expired: {info['expired_entries']}), "
-            f"Evictions: {stats['evictions']}, "
-            f"Invalidations: {stats['invalidations']}"
-        )
 
-
-# Global cache instance
-_cache_manager: Optional[CacheManager] = None
-
-
-def get_cache_manager() -> CacheManager:
-    """
-    Get the global cache manager instance.
-    
-    Returns:
-        Global CacheManager instance
-    """
-    global _cache_manager
-    if _cache_manager is None:
-        _cache_manager = CacheManager()
-    return _cache_manager
-
-
-def initialize_cache(ttl_config: Optional[Dict[CacheDataType, int]] = None) -> CacheManager:
-    """
-    Initialize the global cache manager with custom configuration.
-    
-    Args:
-        ttl_config: Optional custom TTL configuration
-        
-    Returns:
-        Initialized CacheManager instance
-    """
-    global _cache_manager
-    _cache_manager = CacheManager(ttl_config)
-    return _cache_manager
+        logger.debug(f"Cached data for key: {key} (TTL: {ttl}s)")

--- a/sleeper_mcp_server/tools/league_tools.py
+++ b/sleeper_mcp_server/tools/league_tools.py
@@ -11,7 +11,7 @@ from typing import List, Optional
 
 from ..sleeper_client import SleeperClient, SleeperAPIError
 from ..models import League, User, Roster, ErrorResponse
-from ..cache import CacheManager, CacheDataType
+from ..cache import CacheManager, LEAGUE_LIST_TTL, LEAGUE_SETTINGS_TTL, ROSTER_TTL
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"user_leagues:{username}:{season}"
-            cached_result = self.cache.get(cache_key, CacheDataType.LEAGUE_SETTINGS)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -81,7 +81,7 @@ class LeagueTools:
             }
             
             # Cache the result for 1 hour
-            self.cache.set(cache_key, result, CacheDataType.LEAGUE_SETTINGS, ttl_override=3600)
+            self.cache.set(cache_key, result, LEAGUE_LIST_TTL)
             
             logger.info(f"Retrieved {len(leagues)} leagues for user {username}")
             return result
@@ -112,7 +112,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"league_info:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.LEAGUE_SETTINGS)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -154,7 +154,7 @@ class LeagueTools:
             }
             
             # Cache the result for 24 hours (league settings rarely change)
-            self.cache.set(cache_key, result, CacheDataType.LEAGUE_SETTINGS)
+            self.cache.set(cache_key, result, LEAGUE_SETTINGS_TTL)
             
             logger.info(f"Retrieved league info for {league_id}")
             return result
@@ -185,7 +185,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"league_rosters_with_draft:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.ROSTER_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -321,7 +321,7 @@ class LeagueTools:
             }
             
             # Cache the result for 15 minutes (rosters change frequently)
-            self.cache.set(cache_key, result, CacheDataType.ROSTER_DATA)
+            self.cache.set(cache_key, result, ROSTER_TTL)
             
             logger.info(f"Retrieved {len(rosters)} rosters with draft info for league {league_id}")
             return result
@@ -352,7 +352,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"league_rosters:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.ROSTER_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -441,7 +441,7 @@ class LeagueTools:
             }
             
             # Cache the result for 15 minutes (rosters change frequently)
-            self.cache.set(cache_key, result, CacheDataType.ROSTER_DATA)
+            self.cache.set(cache_key, result, ROSTER_TTL)
             
             logger.info(f"Retrieved {len(rosters)} rosters for league {league_id}")
             return result
@@ -472,7 +472,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"league_users:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.LEAGUE_SETTINGS)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -504,7 +504,7 @@ class LeagueTools:
             }
             
             # Cache the result for 1 hour (user list rarely changes mid-season)
-            self.cache.set(cache_key, result, CacheDataType.LEAGUE_SETTINGS, ttl_override=3600)
+            self.cache.set(cache_key, result, LEAGUE_LIST_TTL)
             
             logger.info(f"Retrieved {len(users)} users for league {league_id}")
             return result
@@ -535,7 +535,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"roster_user_mapping:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.ROSTER_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -596,7 +596,7 @@ class LeagueTools:
             }
             
             # Cache the result for 15 minutes
-            self.cache.set(cache_key, result, CacheDataType.ROSTER_DATA, ttl_override=900)
+            self.cache.set(cache_key, result, ROSTER_TTL)
             
             logger.info(f"Retrieved roster-user mapping for {len(roster_mapping)} rosters in league {league_id}")
             return result
@@ -627,7 +627,7 @@ class LeagueTools:
         try:
             # Check cache first
             cache_key = f"league_draft:{league_id}"
-            cached_result = self.cache.get(cache_key, CacheDataType.LEAGUE_SETTINGS)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -745,7 +745,7 @@ class LeagueTools:
             }
             
             # Cache the result for 24 hours (draft data doesn't change)
-            self.cache.set(cache_key, result, CacheDataType.LEAGUE_SETTINGS, ttl_override=86400)
+            self.cache.set(cache_key, result, LEAGUE_SETTINGS_TTL)
             
             logger.info(f"Retrieved draft data with {len(formatted_picks)} picks for league {league_id}")
             return result

--- a/sleeper_mcp_server/tools/matchup_tools.py
+++ b/sleeper_mcp_server/tools/matchup_tools.py
@@ -11,7 +11,7 @@ from typing import List, Optional, Dict, Any
 
 from ..sleeper_client import SleeperClient, SleeperAPIError
 from ..models import Matchup, League, ErrorResponse
-from ..cache import CacheManager, CacheDataType
+from ..cache import CacheManager, MATCHUP_FINAL_TTL, MATCHUP_LIVE_TTL
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +78,7 @@ class MatchupTools:
             
             # Check cache first
             cache_key = f"matchups:{league_id}:{week}"
-            cached_result = self.cache.get(cache_key, CacheDataType.MATCHUP_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -216,9 +216,9 @@ class MatchupTools:
                 any(team["points"] > 0 and team.get("players_points") for team in matchup["teams"])
                 for matchup in formatted_matchups
             )
-            ttl = 300 if is_live else 3600  # 5 minutes if live, 1 hour if completed
+            ttl = MATCHUP_LIVE_TTL if is_live else MATCHUP_FINAL_TTL
             
-            self.cache.set(cache_key, result, CacheDataType.MATCHUP_DATA, ttl_override=ttl)
+            self.cache.set(cache_key, result, ttl)
             
             logger.info(f"Retrieved {len(formatted_matchups)} matchups for league {league_id}, week {week}")
             return result
@@ -261,7 +261,7 @@ class MatchupTools:
             
             # Check cache first (shorter TTL for scores as they update frequently)
             cache_key = f"matchup_scores:{league_id}:{week}"
-            cached_result = self.cache.get(cache_key, CacheDataType.MATCHUP_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -449,9 +449,9 @@ class MatchupTools:
             
             # Cache for 5 minutes during active games, 1 hour for completed weeks
             has_active_scoring = any(score["points"] > 0 for score in matchup_scores)
-            ttl = 300 if has_active_scoring else 3600
+            ttl = MATCHUP_LIVE_TTL if has_active_scoring else MATCHUP_FINAL_TTL
             
-            self.cache.set(cache_key, result, CacheDataType.MATCHUP_DATA, ttl_override=ttl)
+            self.cache.set(cache_key, result, ttl)
             
             logger.info(f"Retrieved scores for {num_teams} teams in league {league_id}, week {week}")
             return result

--- a/sleeper_mcp_server/tools/player_tools.py
+++ b/sleeper_mcp_server/tools/player_tools.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional
 
 from ..sleeper_client import SleeperClient, SleeperAPIError
 from ..models import Player, TrendingPlayer, PlayerStats, ErrorResponse
-from ..cache import CacheManager, CacheDataType
+from ..cache import CacheManager, PLAYER_TTL, TRENDING_TTL
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +43,7 @@ class PlayerTools:
         try:
             # Check cache first
             cache_key = f"search_players:{query}:{position or 'all'}"
-            cached_result = self.cache.get(cache_key, CacheDataType.PLAYER_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -84,7 +84,7 @@ class PlayerTools:
             }
             
             # Cache for 1 hour
-            self.cache.set(cache_key, result, CacheDataType.PLAYER_DATA, ttl_override=3600)
+            self.cache.set(cache_key, result, PLAYER_TTL)
             
             logger.info(f"Found {len(matching_players)} players matching '{query}'")
             return result
@@ -123,7 +123,7 @@ class PlayerTools:
             
             # Check cache first
             cache_key = f"trending_players:{sport}:{add_drop}"
-            cached_result = self.cache.get(cache_key, CacheDataType.PLAYER_DATA)
+            cached_result = self.cache.get(cache_key)
             if cached_result is not None:
                 return cached_result
             
@@ -161,7 +161,7 @@ class PlayerTools:
             }
             
             # Cache for 30 minutes (trending data changes frequently)
-            self.cache.set(cache_key, result, CacheDataType.PLAYER_DATA, ttl_override=1800)
+            self.cache.set(cache_key, result, TRENDING_TTL)
             
             logger.info(f"Retrieved {len(trending_players)} trending {add_drop} players")
             return result
@@ -185,7 +185,7 @@ class PlayerTools:
         """Get a single player's statistics for a season (optionally one week)."""
         try:
             cache_key = f"player_stats:{player_id}:{season}:{week or 'season'}"
-            cached = self.cache.get(cache_key, CacheDataType.PLAYER_DATA)
+            cached = self.cache.get(cache_key)
             if cached is not None:
                 return cached
 
@@ -204,7 +204,7 @@ class PlayerTools:
                 "team": info.team if info else "Unknown",
                 "stats": stats,
             }
-            self.cache.set(cache_key, result, CacheDataType.PLAYER_DATA, ttl_override=3600)
+            self.cache.set(cache_key, result, PLAYER_TTL)
             return result
         except SleeperAPIError as e:
             logger.error(f"API error getting player stats: {e}")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,46 @@
+from sleeper_mcp_server import cache as cache_module
+from sleeper_mcp_server.cache import CacheManager
+
+
+class FakeClock:
+    """Stands in for the `time` module inside cache.py so TTLs are deterministic."""
+
+    def __init__(self, now: float = 1_000_000.0):
+        self._now = now
+
+    def time(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += seconds
+
+
+def test_set_then_get_returns_the_value():
+    c = CacheManager()
+    c.set("league_info:123", {"name": "BDNB"}, 900)
+    assert c.get("league_info:123") == {"name": "BDNB"}
+
+
+def test_get_returns_none_for_an_absent_key():
+    assert CacheManager().get("never_written") is None
+
+
+def test_get_returns_none_once_the_ttl_has_elapsed(monkeypatch):
+    clock = FakeClock()
+    monkeypatch.setattr(cache_module, "time", clock)
+
+    c = CacheManager()
+    c.set("rosters:123", ["a", "b"], 900)
+
+    clock.advance(899)
+    assert c.get("rosters:123") == ["a", "b"]
+
+    clock.advance(2)
+    assert c.get("rosters:123") is None
+
+
+def test_set_overwrites_an_existing_key():
+    c = CacheManager()
+    c.set("matchups:123:4", {"points": 100.0}, 300)
+    c.set("matchups:123:4", {"points": 120.5}, 300)
+    assert c.get("matchups:123:4") == {"points": 120.5}


### PR DESCRIPTION
Candidate 1 from an architecture review of this repo.

## What

`CacheManager` published 375 lines of interface, but all 24 call sites reached only `get` and `set`. Lines 145–375 had **zero callers** — verified both here and in the `sleeper-analytics` consumer, which installs this package editable against this tree:

`invalidate` · `invalidate_by_pattern` · `invalidate_by_type` · `clear` · `cleanup_expired` · `get_stats` · `get_cache_info` · `get_matchup_ttl` · `log_performance_summary` · `get_cache_manager` · `initialize_cache`

The `_stats` counters go with them — nothing read them once those methods were gone.

Nothing in this server writes to Sleeper (all 13 tools are `readOnlyHint=True`), so no event exists that could invalidate an entry early. TTL expiry is the only mechanism there is.

## Also: the CacheDataType enum

It competed with `ttl_override` as a second way to state one decision, and lost — 9 of 12 `set` calls already bypassed the TTL table, and 2 of those "overrides" restated the default they were overriding. Callers now pass a TTL directly, named by module-level constants:

| constant | seconds | used by |
|---|---|---|
| `LEAGUE_SETTINGS_TTL` | 86400 | league info, draft results |
| `LEAGUE_LIST_TTL` | 3600 | a user's leagues, a league's users |
| `ROSTER_TTL` | 900 | rosters |
| `PLAYER_TTL` | 3600 | player search, player stats |
| `TRENDING_TTL` | 1800 | trending adds/drops |
| `MATCHUP_LIVE_TTL` / `MATCHUP_FINAL_TTL` | 300 / 3600 | live vs completed week |

`get(key)` · `set(key, data, ttl)`. The `threading.Lock` stays.

## Behaviour is identical

Every TTL after this change equals the TTL before it. The two no-op `ttl_override` arguments already matched their defaults; the three sites that relied on a default now state it explicitly at the same value.

## Verification

- `26 passed` here — 22 existing plus 4 new in `tests/test_cache.py`, the first direct coverage of the surviving interface
- `326 passed` in `sleeper-analytics`
- 13 tools still register on the FastMCP app
- mypy: 73 errors across 7 files → 68 across 6; `cache.py` is now clean
- flake8 clean on changed files

`cache.py`: 375 → 100 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)